### PR TITLE
Add user prompt history routes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,7 @@ const protectedRoutes = require('./routes/protectedRoutes');
 const evaluationRoutes = require('./routes/evaluationRoutes');
 const taskRoutes = require('./routes/taskRoutes');
 const badgeRoutes = require("./routes/badgeRoutes");
+const promptHistoryRoutes = require('./routes/promptHistoryRoutes');
 
 dotenv.config();
 
@@ -25,6 +26,7 @@ app.use(bodyParser.json());
 app.use('/api/auth', authRoutes);
 app.use('/api/user', protectedRoutes);   // z. B. /api/user/me
 app.use('/api/user', userRoutes);        // z. B. /api/user/:id
+app.use('/api/user', promptHistoryRoutes); // /api/user/:id/prompt-history
 app.use('/api/badges', badgeRoutes);     // z. B. /api/badges/:userId
 app.use('/api/evaluation', evaluationRoutes);
 app.use('/api/tasks', taskRoutes);

--- a/src/routes/promptHistoryRoutes.js
+++ b/src/routes/promptHistoryRoutes.js
@@ -1,0 +1,55 @@
+const express = require('express');
+const router = express.Router();
+const db = require('../config/db');
+const authMiddleware = require('../middleware/authMiddleware');
+
+// Alle vergangenen Prompts eines Users abrufen
+router.get('/:id/prompt-history', authMiddleware, async (req, res) => {
+  const userId = req.params.id;
+
+  try {
+    const result = await db.query(
+      `SELECT p.id, p.content, p.created_at, pr.score, pr.feedback, pr.keyword_hits
+         FROM prompts p
+         LEFT JOIN prompt_results pr ON pr.prompt_id = p.id
+        WHERE p.user_id = $1
+        ORDER BY p.created_at DESC`,
+      [userId]
+    );
+
+    res.json(result.rows);
+  } catch (err) {
+    console.error('Fehler beim Abrufen der Prompt-Historie:', err);
+    res.status(500).json({ error: 'Interner Serverfehler' });
+  }
+});
+
+// Prompt samt Ergebnis löschen
+router.delete('/:id/prompt-history/:promptId', authMiddleware, async (req, res) => {
+  const userId = req.params.id;
+  const promptId = req.params.promptId;
+
+  try {
+    await db.query('BEGIN');
+
+    await db.query('DELETE FROM prompt_results WHERE prompt_id = $1', [promptId]);
+    const result = await db.query(
+      'DELETE FROM prompts WHERE id = $1 AND user_id = $2',
+      [promptId, userId]
+    );
+
+    await db.query('COMMIT');
+
+    if (result.rowCount === 0) {
+      return res.status(404).json({ error: 'Prompt nicht gefunden' });
+    }
+
+    res.json({ message: 'Prompt gelöscht' });
+  } catch (err) {
+    await db.query('ROLLBACK');
+    console.error('Fehler beim Löschen des Prompts:', err);
+    res.status(500).json({ error: 'Interner Serverfehler' });
+  }
+});
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- add new `/user/:id/prompt-history` router with GET and DELETE
- mount router in Express app

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint` *(fails: ESLint couldn't find a config file)*

------
https://chatgpt.com/codex/tasks/task_e_685d95a6356883208cef4a42159ff2b0